### PR TITLE
Fix for self-bots

### DIFF
--- a/litcord/client/Client.lua
+++ b/litcord/client/Client.lua
@@ -541,7 +541,9 @@ function Client:login (tmail, password)
 		end
 		self.socket.token = response.token
 	end
-	self.socket.token = 'Bot '..self.socket.token
+	if not self.socket.token:sub(1,3):lower() == 'mfa' then
+		self.socket.token = 'Bot '.. self.socket.token
+	end
 	self.socket:connect()
 end
 


### PR DESCRIPTION
Allows self-bots to be able to use Litcord.

Thanks to https://github.com/woiph for finding the way to do this.
