### PR TITLE
Fixed getHistory function.

### DIFF
--- a/litcord/structures/Channel.lua
+++ b/litcord/structures/Channel.lua
@@ -32,16 +32,21 @@ function Channel:sendFile (file, content, config) -- multipart/form-data
 	return self:sendMessage(content, config)
 end
 
-function Channel:getHistory (limit, config)
+function Channel:getHistory (limit, around, before, after) -- around, before and after not needed
+	extra =  {
+			"around" = around,
+			"before" = before,
+			"after" = after,
+		}
 	local data = self.parent.parent.rest:request(
 		{
 			method = 'GET',
 			path = 'channels/'..self.id..'/messages',
 			data = utils.merge(
 				{
-					limit = limit,
+					"limit" = limit,
 				},
-				config
+				extra or {}
 			),
 		}
 	)


### PR DESCRIPTION
In the moment of making the GET request you were sending a table with a number, where limit was that number since it was not a string / index in the table, this way limit will be numbers of messages you want to receive and "limit" the JSON param.

Also fixed rest data.
